### PR TITLE
cluster: gracefully shutdown gRPC server

### DIFF
--- a/cluster/member.go
+++ b/cluster/member.go
@@ -130,7 +130,10 @@ func (m *Member) Stop() {
 	m.statusLock.Unlock()
 
 	// TODO: stop with/without leadership transfer?
-	m.srv.Server.HardStop()
+	// m.srv.Server.HardStop()
+
+	// stops embedded server to trigger
+	// gRPC server graceful shutdown
 	m.srv.Close()
 
 	var cerr error


### PR DESCRIPTION
Fix https://travis-ci.org/coreos/etcdlabs/builds/226865093?utm_source=email&utm_medium=notification.
